### PR TITLE
Added extra features for hardcore hunger.

### DIFF
--- a/src/main/java/net/darkhax/betterhunger/Configuration.java
+++ b/src/main/java/net/darkhax/betterhunger/Configuration.java
@@ -2,6 +2,7 @@ package net.darkhax.betterhunger;
 
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
+import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 
 public class Configuration {
     
@@ -11,6 +12,10 @@ public class Configuration {
     private final BooleanValue hideFoodBar;
     private final BooleanValue neverHungry;
     private final BooleanValue instantHungerDeath;
+    private final BooleanValue hc;
+    private final ConfigValue<Double> hchunger;
+    private final ConfigValue<Integer> hcbreak;
+    private final ConfigValue<Double> hcswimming;
     
     public Configuration() {
         
@@ -18,7 +23,7 @@ public class Configuration {
         
         // General Configs
         builder.comment("General settings for the mod.");
-        builder.push("general");
+        builder.push("General");
         
         builder.comment("Should food always be edible?");
         this.alwaysEdible = builder.define("always-edible", true);
@@ -32,6 +37,16 @@ public class Configuration {
         builder.comment("Should players insta-die if they run out of food?");
         this.instantHungerDeath = builder.define("hardcore-hunger", false);
         
+        builder.pop();
+        builder.push("Hardcore Hunger");
+        builder.comment("In order for these features to work properly you need neverHungry = false !!!\nShould Harcore Hunger mode be enabled?");
+        this.hc = builder.define("harcore", false);
+        builder.comment("How much hunger will you lose every tick? 20 ticks = 1 second\ndefault value = 0.01\nfor reference, the vanilla sprinting value = 0.1");
+        this.hchunger = builder.define("harcore-depletion", 0.01);  //Vanilla sprinting is 0.1
+        builder.comment("You can no longer break ANY blocks below this amount of shanks. Hunger is divided by 2.\nExample: 13 = 6.5 shanks\nExample: 6 = 3 shanks\ndefault value = 6\n-1 removes this feature");
+        this.hcbreak = builder.define("harcore-breaking", 6);
+        builder.comment("Swimming and/or being inside water depletes your hunger every tick.\ndefault value = 0.02\nfor reference, the vanilla sprinting value = 0.1");
+        this.hcswimming = builder.define("hardcore-swimming", 0.01);
         builder.pop();
         this.spec = builder.build();
     }
@@ -60,4 +75,24 @@ public class Configuration {
         
         return this.instantHungerDeath.get();
     }
+    
+    public boolean hc () {
+    	
+    	return this.hc.get();
+    }
+    
+    public Double hchunger () {
+    	
+    	return this.hchunger.get();
+    }
+    
+    public Integer hcbreak () {
+    	
+    	return this.hcbreak.get();
+    }
+    
+    public Double hcswimming() {
+    	return this.hcswimming.get();
+    }
+
 }


### PR DESCRIPTION
Based on https://minecraft.gamepedia.com/Hunger I am proposing the following few additions to the mod. I am not a programmer by any means , still trying to learn. I wanted some specific functionality regarding hunger fro my modpack and was considering making my own mod about it but since I would base it around this mod anyway, why not send them here directly.

Added a way to stop the player from mining blocks if the hunger is lower than a value. This is done by utilizing the BreakSpeed event of PlayerEvent setting it to zero.
Added hunger exhaustion on PlayerTickEvent for passive hunger. (This does not help with #2 , it simply adds even more exhaustion instead.)
Added hunger exhaustion on LivingUpdateEvent for depleting hunger on swimming players or players inside water. This still needs work. Possibly checking if the player is moving when he is in the water and not depleting hunger if he is standing there.

Added all the new options in the config.

All the feedback is very much appreciated.
Thank you for taking the time.